### PR TITLE
chore: bump versions to 0.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To use the SDK with Maven add the following to your `pom.xml` to add the SDK as 
     <groupId>com.etospheres.etopay</groupId>
     <artifactId>etopaysdk</artifactId>
     <scope>compile</scope>
-    <version>0.16.0</version>
+    <version>0.16.1</version>
   </dependency>
   ...
 </dependencies>

--- a/gradle-android/gradle/libs.versions.toml
+++ b/gradle-android/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ espressoCore = "3.5.1"
 lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.09.00"
-etopaysdk = "0.16.0"
+etopaysdk = "0.16.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/gradle-java/app/build.gradle
+++ b/gradle-java/app/build.gradle
@@ -37,8 +37,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // This dependency is used by the application.
-	implementation 'com.etospheres.etopay:etopaysdk:0.16.0'
-	natives 'com.etospheres.etopay:etopaysdk:0.16.0:natives-linux'
+	implementation 'com.etospheres.etopay:etopaysdk:0.16.1'
+	natives 'com.etospheres.etopay:etopaysdk:0.16.1:natives-linux'
 }
 
 task unzipNatives(type: Copy) {

--- a/maven-example/pom.xml
+++ b/maven-example/pom.xml
@@ -32,7 +32,7 @@
       <groupId>com.etospheres.etopay</groupId>
       <artifactId>etopaysdk</artifactId>
       <scope>compile</scope>
-      <version>0.16.0</version>
+      <version>0.16.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
`0.16.0` -> `0.16.1`